### PR TITLE
퍼사드 패턴 가이드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.6'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.6'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.spartaclub'
@@ -9,55 +9,57 @@ version = '0.0.1-SNAPSHOT'
 description = 'Demo project for Spring Boot'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
-	google()
+    mavenCentral()
+    google()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-cache'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 
-	// JWT
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-	runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'org.postgresql:postgresql'
 
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
-	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testRuntimeOnly 'com.h2database:h2'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'com.h2database:h2'
 
-	implementation 'com.google.genai:google-genai:1.0.0'
+    implementation 'com.google.genai:google-genai:1.0.0'
+
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/application/dto/StoreInfoDto.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/application/dto/StoreInfoDto.java
@@ -1,0 +1,19 @@
+package com.spartaclub.orderplatform.domain.order.application.dto;
+
+import com.spartaclub.orderplatform.domain.order.domain.repository.dto.StoreSummary;
+import java.util.UUID;
+
+public record StoreInfoDto(
+    UUID storeId,
+    String storeName,
+    Long ownerId
+) {
+
+    public static StoreInfoDto from(StoreSummary store) {
+        return new StoreInfoDto(
+            store.storeId(),
+            store.storeName(),
+            store.ownerId()
+        );
+    }
+}

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/application/facade/OrderPublicReader.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/application/facade/OrderPublicReader.java
@@ -1,0 +1,16 @@
+package com.spartaclub.orderplatform.domain.order.application.facade;
+
+import com.spartaclub.orderplatform.domain.order.application.facade.dto.OrderView;
+import java.util.Optional;
+import java.util.UUID;
+
+/*
+    공개용 인터페이스(퍼사드)
+    다른 도메인에서 Order 관련 데이터는 반드시 이 인터페이스를 통해서만 접근
+    내부 로직을 감추고 단일 진입점 제공
+ */
+public interface OrderPublicReader {
+
+    Optional<OrderView> loadOrderSummaryInfo(UUID orderId);
+
+}

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/application/facade/OrderPublicReaderImpl.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/application/facade/OrderPublicReaderImpl.java
@@ -1,0 +1,20 @@
+package com.spartaclub.orderplatform.domain.order.application.facade;
+
+import com.spartaclub.orderplatform.domain.order.application.facade.dto.OrderView;
+import com.spartaclub.orderplatform.domain.order.domain.repository.OrderRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderPublicReaderImpl implements OrderPublicReader {
+
+    private final OrderRepository orderRepository;
+
+    @Override
+    public Optional<OrderView> loadOrderSummaryInfo(UUID orderId) {
+        return orderRepository.findById(orderId).map(OrderView::from);
+    }
+}

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/application/facade/dto/OrderView.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/application/facade/dto/OrderView.java
@@ -1,0 +1,23 @@
+package com.spartaclub.orderplatform.domain.order.application.facade.dto;
+
+import com.spartaclub.orderplatform.domain.order.domain.model.Order;
+import java.util.UUID;
+
+public record OrderView(
+    UUID orderId,
+    Long customerId,
+    Long totalPrice,
+    Integer productCount,
+    String status
+) {
+
+    public static OrderView from(Order order) {
+        return new OrderView(
+            order.getOrderId(),
+            order.getCreatedId(),
+            order.getTotalPrice(),
+            order.getProductCount(),
+            order.getStatus().toString()
+        );
+    }
+}

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/application/mapper/OrderMapper.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/application/mapper/OrderMapper.java
@@ -17,7 +17,7 @@ public interface OrderMapper {
     // Order -> OrderDetailResponseDto 변환
     @Mapping(source = "orderProducts", target = "productsList")
     @Mapping(source = "user.userId", target = "userId")
-    @Mapping(source = "store.storeId", target = "storeId")
+    @Mapping(source = "storeId", target = "storeId")
     OrderDetailResponseDto toDto(Order order);
 
     // OrderProduct -> ProductsListItem
@@ -29,7 +29,7 @@ public interface OrderMapper {
 
     // Order -> OrderSummaryDto
     @Mapping(source = "user.userId", target = "userId")
-    @Mapping(source = "store.storeId", target = "storeId")
+    @Mapping(source = "storeId", target = "storeId")
     OrdersResponseDto.OrderSummaryDto toSummaryDto(Order order);
 
     PlaceOrderCommand toCommand(OrderItemRequest requestDto);

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/application/query/OrderSpecQuery.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/application/query/OrderSpecQuery.java
@@ -4,7 +4,7 @@ import com.spartaclub.orderplatform.domain.order.domain.model.OrderStatus;
 import com.spartaclub.orderplatform.domain.user.domain.entity.User;
 import java.util.List;
 
-public record OrderQuery(
+public record OrderSpecQuery(
     List<OrderStatus> status,
     User viewer
 ) {

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/application/query/StoreQuery.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/application/query/StoreQuery.java
@@ -1,0 +1,9 @@
+package com.spartaclub.orderplatform.domain.order.application.query;
+
+import java.util.UUID;
+
+public record StoreQuery(
+    UUID storeId
+) {
+
+}

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/application/service/OrderService.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/application/service/OrderService.java
@@ -1,10 +1,11 @@
-package com.spartaclub.orderplatform.domain.order.application;
+package com.spartaclub.orderplatform.domain.order.application.service;
 
 import static java.util.function.UnaryOperator.identity;
 
 import com.spartaclub.orderplatform.domain.order.application.command.PlaceOrderCommand;
+import com.spartaclub.orderplatform.domain.order.application.dto.StoreInfoDto;
 import com.spartaclub.orderplatform.domain.order.application.mapper.OrderMapper;
-import com.spartaclub.orderplatform.domain.order.application.query.OrderQuery;
+import com.spartaclub.orderplatform.domain.order.application.query.StoreQuery;
 import com.spartaclub.orderplatform.domain.order.domain.model.Order;
 import com.spartaclub.orderplatform.domain.order.domain.model.OrderStatus;
 import com.spartaclub.orderplatform.domain.order.domain.repository.OrderRepository;
@@ -12,19 +13,13 @@ import com.spartaclub.orderplatform.domain.order.domain.repository.ProductReader
 import com.spartaclub.orderplatform.domain.order.domain.repository.StoreReaderRepository;
 import com.spartaclub.orderplatform.domain.order.exception.OrderErrorCode;
 import com.spartaclub.orderplatform.domain.order.exception.StoreRefErrorCode;
-import com.spartaclub.orderplatform.domain.order.presentation.dto.request.GetOrdersRequestDto;
 import com.spartaclub.orderplatform.domain.order.presentation.dto.request.PlaceOrderRequestDto;
 import com.spartaclub.orderplatform.domain.order.presentation.dto.request.PlaceOrderRequestDto.OrderItemRequest;
-import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrderDetailResponseDto;
 import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrderStatusResponseDto;
-import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrdersResponseDto;
-import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrdersResponseDto.OrderSummaryDto;
 import com.spartaclub.orderplatform.domain.order.presentation.dto.response.PlaceOrderResponseDto;
 import com.spartaclub.orderplatform.domain.product.domain.entity.Product;
-import com.spartaclub.orderplatform.domain.store.domain.model.Store;
 import com.spartaclub.orderplatform.domain.user.domain.entity.User;
 import com.spartaclub.orderplatform.global.auth.UserDetailsImpl;
-import com.spartaclub.orderplatform.global.auth.exception.AuthErrorCode;
 import com.spartaclub.orderplatform.global.exception.BusinessException;
 import java.util.List;
 import java.util.Map;
@@ -32,8 +27,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -57,76 +50,16 @@ public class OrderService {
         //상품Id, 수량 commands
         List<PlaceOrderCommand> commands = items.stream().map(orderMapper::toCommand).toList();
 
-        Store store = loadStore(placeOrderRequestDto.storeId(), user.getUserId());
+        StoreQuery storeQuery = new StoreQuery(placeOrderRequestDto.storeId());
+        StoreInfoDto storeInfoDto = loadStoreSummaryInfo(storeQuery, user.getUserId());
 
-        Order order = Order.place(user, store, commands, productMap, placeOrderRequestDto.address(),
+        Order order = Order.place(user, storeInfoDto.storeId(), commands, productMap,
+            placeOrderRequestDto.address(),
             placeOrderRequestDto.memo());
 
         order = orderRepository.save(order);
 
         return new PlaceOrderResponseDto(order.getOrderId());
-    }
-
-    //주문 상세 조회
-    @Transactional(readOnly = true)
-    public OrderDetailResponseDto getOrderDetail(UUID orderId,
-        UserDetailsImpl userDetails) {
-        User viewer = userDetails.getUser();
-        Order order = findById(orderId);
-
-        switch (viewer.getRole()) {
-            case CUSTOMER -> {
-                // 본인 주문만
-                Long ownerUserId = order.getUser().getUserId();
-                Long viewerUserId = viewer.getUserId();
-                if (!ownerUserId.equals(viewerUserId)) {
-                    log.warn(
-                        "CUSTOMER는 본인의 주문만 조회할 수 있습니다. : role={}, viewerId={}, ownerId={}, orderId={}",
-                        viewer.getRole(), viewerUserId, ownerUserId, orderId);
-                    throw new BusinessException(AuthErrorCode.FORBIDDEN);
-                }
-            }
-            case OWNER -> {
-                // 본인 가게 주문만
-                Long storeOwnerId = order.getStore().getUser().getUserId();
-                Long viewerUserId = viewer.getUserId();
-                if (!storeOwnerId.equals(viewerUserId)) {
-                    log.warn(
-                        "OWNER는 본인 가게의 주문만 조회할 수 있습니다. : role={}, viewerId={}, storeOwnerId={}, orderId={}",
-                        viewer.getRole(), viewerUserId, storeOwnerId, orderId);
-                    throw new BusinessException(AuthErrorCode.FORBIDDEN);
-                }
-            }
-            case MANAGER, MASTER -> {
-                // 모두 가능: 추가 검증 없음
-            }
-            default -> {
-                log.warn("해당 역할은 주문 조회 권한이 없습니다. : role={}, viewerId={}, orderId={}",
-                    viewer.getRole(), viewer.getUserId(), orderId);
-                throw new BusinessException(AuthErrorCode.FORBIDDEN);
-            }
-        }
-        return orderMapper.toDto(order);
-    }
-
-    //주문 목록 조회
-    @Transactional(readOnly = true)
-    public OrdersResponseDto getOrders(GetOrdersRequestDto requestDto,
-        UserDetailsImpl userDetails,
-        Pageable pageable) {
-        User viewer = userDetails.getUser();
-
-        //조회
-        OrderQuery orderQuery = new OrderQuery(requestDto.status(), viewer);
-        Page<Order> orders = orderRepository.findAll(orderQuery, pageable);
-
-        List<OrderSummaryDto> ordersList = orders.getContent().stream()
-            .map(orderMapper::toSummaryDto)
-            .collect(Collectors.toList());
-
-        OrdersResponseDto.PageableDto meta = orderMapper.toPageableDto(orders);
-
-        return new OrdersResponseDto(ordersList, meta);
     }
 
     //주문 취소
@@ -178,22 +111,6 @@ public class OrderService {
         return OrderStatusResponseDto.ofDelivered(orderId);
     }
 
-    public Order findById(UUID orderId) {
-        return orderRepository.findById(orderId)
-            .orElseThrow(() -> {
-                log.warn("[Order] NOT_EXIST - orderId={}", orderId);
-                return new BusinessException(OrderErrorCode.NOT_EXIST);
-            });
-    }
-
-    private Store loadStore(UUID storeId, Long userId) {
-        return storeReaderRepository.findById(storeId)
-            .orElseThrow(() -> {
-                log.warn("[Store] NOT_EXIST - storeId={}, userId={}", storeId, userId);
-                return new BusinessException(StoreRefErrorCode.NOT_EXIST);
-            });
-    }
-
     // 상품 로딩(IN) → id->Product 맵
     private Map<UUID, Product> loadProductMap(List<OrderItemRequest> items) {
         List<UUID> ids = items.stream()
@@ -202,5 +119,22 @@ public class OrderService {
 
         return productReaderRepository.findByProductIdIn(ids).stream()
             .collect(Collectors.toMap(Product::getProductId, identity()));
+    }
+
+    public Order findById(UUID orderId) {
+        return orderRepository.findById(orderId)
+            .orElseThrow(() -> {
+                log.warn("[OrderReader] NOT_EXIST - orderId={}", orderId);
+                return new BusinessException(OrderErrorCode.NOT_EXIST);
+            });
+    }
+
+    public StoreInfoDto loadStoreSummaryInfo(StoreQuery query, Long userId) {
+        return storeReaderRepository.loadStoreSummaryInfo(query.storeId())
+            .map(StoreInfoDto::from)
+            .orElseThrow(() -> {
+                log.warn("[Store] NOT_EXIST - storeId={}, userId={}", query.storeId(), userId);
+                return new BusinessException(StoreRefErrorCode.NOT_EXIST);
+            });
     }
 }

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/application/service/query/OrderCustomerQueryService.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/application/service/query/OrderCustomerQueryService.java
@@ -1,0 +1,53 @@
+package com.spartaclub.orderplatform.domain.order.application.service.query;
+
+
+import com.spartaclub.orderplatform.domain.order.domain.model.Order;
+import com.spartaclub.orderplatform.domain.order.presentation.dto.request.GetOrdersRequestDto;
+import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrderDetailResponseDto;
+import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrdersResponseDto;
+import com.spartaclub.orderplatform.domain.user.domain.entity.User;
+import com.spartaclub.orderplatform.domain.user.domain.entity.UserRole;
+import com.spartaclub.orderplatform.global.auth.exception.AuthErrorCode;
+import com.spartaclub.orderplatform.global.exception.BusinessException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class OrderCustomerQueryService implements OrderRoleQuery {
+
+    private final OrderReader orderReader;
+
+    @Override
+    public UserRole supports() {
+        return UserRole.CUSTOMER;
+    }
+
+    @Override
+    public OrderDetailResponseDto getOrderDetail(UUID orderId, User viewer) {
+        Order order = orderReader.findById(orderId);
+
+        // 본인 주문만
+        Long odererId = order.getUser().getUserId();
+        Long viewerId = viewer.getUserId();
+        if (!odererId.equals(viewerId)) {
+            log.warn(
+                "CUSTOMER는 본인의 주문만 조회할 수 있습니다. : role={}, viewerId={}, odererId={}, orderId={}",
+                viewer.getRole(), viewerId, odererId, orderId);
+            throw new BusinessException(AuthErrorCode.FORBIDDEN);
+        }
+        return orderMapper.toDto(order);
+    }
+
+    @Override
+    public OrdersResponseDto getOrders(GetOrdersRequestDto requestDto, User viewer,
+        Pageable pageable) {
+        return getOrdersCommon(requestDto, viewer, pageable, orderReader, orderMapper);
+    }
+}

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/application/service/query/OrderManagerQueryService.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/application/service/query/OrderManagerQueryService.java
@@ -1,0 +1,37 @@
+package com.spartaclub.orderplatform.domain.order.application.service.query;
+
+import com.spartaclub.orderplatform.domain.order.presentation.dto.request.GetOrdersRequestDto;
+import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrderDetailResponseDto;
+import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrdersResponseDto;
+import com.spartaclub.orderplatform.domain.user.domain.entity.User;
+import com.spartaclub.orderplatform.domain.user.domain.entity.UserRole;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderManagerQueryService implements OrderRoleQuery {
+
+    private final OrderReader orderReader;
+
+    @Override
+    public UserRole supports() {
+        return UserRole.MANAGER;
+    }
+
+    @Override
+    public OrderDetailResponseDto getOrderDetail(UUID orderId, User viewer) {
+        return orderMapper.toDto(orderReader.findById(orderId));
+    }
+
+    @Override
+    public OrdersResponseDto getOrders(GetOrdersRequestDto requestDto, User viewer,
+        Pageable pageable) {
+        return getOrdersCommon(requestDto, viewer, pageable, orderReader, orderMapper);
+    }
+
+}

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/application/service/query/OrderMasterQueryService.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/application/service/query/OrderMasterQueryService.java
@@ -1,0 +1,38 @@
+package com.spartaclub.orderplatform.domain.order.application.service.query;
+
+import com.spartaclub.orderplatform.domain.order.presentation.dto.request.GetOrdersRequestDto;
+import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrderDetailResponseDto;
+import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrdersResponseDto;
+import com.spartaclub.orderplatform.domain.user.domain.entity.User;
+import com.spartaclub.orderplatform.domain.user.domain.entity.UserRole;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class OrderMasterQueryService implements OrderRoleQuery {
+
+    private final OrderReader orderReader;
+
+    @Override
+    public UserRole supports() {
+        return UserRole.MASTER;
+    }
+
+    @Override
+    public OrderDetailResponseDto getOrderDetail(UUID orderId, User viewer) {
+        return orderMapper.toDto(orderReader.findById(orderId));
+    }
+
+    @Override
+    public OrdersResponseDto getOrders(GetOrdersRequestDto requestDto, User viewer,
+        Pageable pageable) {
+        return getOrdersCommon(requestDto, viewer, pageable, orderReader, orderMapper);
+    }
+}

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/application/service/query/OrderOwnerQueryService.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/application/service/query/OrderOwnerQueryService.java
@@ -1,0 +1,70 @@
+package com.spartaclub.orderplatform.domain.order.application.service.query;
+
+import com.spartaclub.orderplatform.domain.order.application.dto.StoreInfoDto;
+import com.spartaclub.orderplatform.domain.order.application.query.StoreQuery;
+import com.spartaclub.orderplatform.domain.order.domain.model.Order;
+import com.spartaclub.orderplatform.domain.order.domain.repository.StoreReaderRepository;
+import com.spartaclub.orderplatform.domain.order.exception.StoreRefErrorCode;
+import com.spartaclub.orderplatform.domain.order.presentation.dto.request.GetOrdersRequestDto;
+import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrderDetailResponseDto;
+import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrdersResponseDto;
+import com.spartaclub.orderplatform.domain.user.domain.entity.User;
+import com.spartaclub.orderplatform.domain.user.domain.entity.UserRole;
+import com.spartaclub.orderplatform.global.auth.exception.AuthErrorCode;
+import com.spartaclub.orderplatform.global.exception.BusinessException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class OrderOwnerQueryService implements OrderRoleQuery {
+
+    private final OrderReader orderReader;
+    private final StoreReaderRepository storeReaderRepository;
+
+    @Override
+    public UserRole supports() {
+        return UserRole.OWNER;
+    }
+
+    @Override
+    public OrderDetailResponseDto getOrderDetail(UUID orderId, User viewer) {
+        Order order = orderReader.findById(orderId);
+
+        StoreQuery storeQuery = new StoreQuery(order.getStoreId());
+        StoreInfoDto storeInfoDto = loadStoreSummaryInfo(storeQuery,
+            viewer.getUserId());
+
+        // 본인 가게 주문만
+        Long storeOwnerId = storeInfoDto.ownerId();
+        Long viewerUserId = viewer.getUserId();
+        if (!storeOwnerId.equals(viewerUserId)) {
+            log.warn(
+                "OWNER는 본인 가게의 주문만 조회할 수 있습니다. : role={}, viewerId={}, storeOwnerId={}, orderId={}",
+                viewer.getRole(), viewerUserId, storeOwnerId, orderId);
+            throw new BusinessException(AuthErrorCode.FORBIDDEN);
+        }
+        return orderMapper.toDto(order);
+    }
+
+    @Override
+    public OrdersResponseDto getOrders(GetOrdersRequestDto requestDto, User viewer,
+        Pageable pageable) {
+        return getOrdersCommon(requestDto, viewer, pageable, orderReader, orderMapper);
+    }
+
+    private StoreInfoDto loadStoreSummaryInfo(StoreQuery query, Long userId) {
+        return storeReaderRepository.loadStoreSummaryInfo(query.storeId())
+            .map(StoreInfoDto::from)
+            .orElseThrow(() -> {
+                log.warn("[Store] NOT_EXIST - storeId={}, userId={}", query.storeId(), userId);
+                return new BusinessException(StoreRefErrorCode.NOT_EXIST);
+            });
+    }
+}

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/application/service/query/OrderQueryFacade.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/application/service/query/OrderQueryFacade.java
@@ -1,0 +1,50 @@
+package com.spartaclub.orderplatform.domain.order.application.service.query;
+
+import com.spartaclub.orderplatform.domain.order.presentation.dto.request.GetOrdersRequestDto;
+import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrderDetailResponseDto;
+import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrdersResponseDto;
+import com.spartaclub.orderplatform.domain.user.domain.entity.User;
+import com.spartaclub.orderplatform.domain.user.domain.entity.UserRole;
+import com.spartaclub.orderplatform.global.auth.exception.AuthErrorCode;
+import com.spartaclub.orderplatform.global.exception.BusinessException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class OrderQueryFacade {
+
+    private final Map<UserRole, OrderRoleQuery> orderRoleQueryMap;
+
+    public OrderQueryFacade(List<OrderRoleQuery> orderRoleQueries) {
+        // 전달받은 List를 Map<UserRole, OrderRoleQuery>으로 변환
+        orderRoleQueryMap = orderRoleQueries.stream()
+            .collect(Collectors.toUnmodifiableMap(OrderRoleQuery::supports, it -> it));
+    }
+
+    public OrderDetailResponseDto getOrderDetail(UUID orderId, User viewer) {
+        OrderRoleQuery strategy = orderRoleQueryMap.get(viewer.getRole());
+        if (strategy == null) {
+            throw new BusinessException(AuthErrorCode.FORBIDDEN);
+        }
+        return strategy.getOrderDetail(orderId, viewer);
+    }
+
+    public OrdersResponseDto getOrders(
+        GetOrdersRequestDto requestDto,
+        User viewer,
+        Pageable pageable) {
+
+        OrderRoleQuery strategy = orderRoleQueryMap.get(viewer.getRole());
+        if (strategy == null) {
+            throw new BusinessException(AuthErrorCode.FORBIDDEN);
+        }
+        return strategy.getOrders(requestDto, viewer, pageable);
+    }
+
+}

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/application/service/query/OrderReader.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/application/service/query/OrderReader.java
@@ -1,0 +1,36 @@
+package com.spartaclub.orderplatform.domain.order.application.service.query;
+
+import com.spartaclub.orderplatform.domain.order.application.query.OrderSpecQuery;
+import com.spartaclub.orderplatform.domain.order.domain.model.Order;
+import com.spartaclub.orderplatform.domain.order.domain.repository.OrderRepository;
+import com.spartaclub.orderplatform.domain.order.exception.OrderErrorCode;
+import com.spartaclub.orderplatform.global.exception.BusinessException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+class OrderReader {
+
+    private final OrderRepository orderRepository;
+
+    Order findById(UUID orderId) {
+        return orderRepository.findById(orderId)
+            .orElseThrow(() -> {
+                log.warn("[OrderReader] NOT_EXIST - orderId={}", orderId);
+                return new BusinessException(OrderErrorCode.NOT_EXIST);
+            });
+    }
+
+    Page<Order> findAll(OrderSpecQuery orderSpecQuery, Pageable pageable) {
+        return orderRepository.findAll(orderSpecQuery, pageable);
+    }
+
+}

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/application/service/query/OrderRoleQuery.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/application/service/query/OrderRoleQuery.java
@@ -1,0 +1,48 @@
+package com.spartaclub.orderplatform.domain.order.application.service.query;
+
+import com.spartaclub.orderplatform.domain.order.application.mapper.OrderMapper;
+import com.spartaclub.orderplatform.domain.order.application.query.OrderSpecQuery;
+import com.spartaclub.orderplatform.domain.order.domain.model.Order;
+import com.spartaclub.orderplatform.domain.order.presentation.dto.request.GetOrdersRequestDto;
+import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrderDetailResponseDto;
+import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrdersResponseDto;
+import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrdersResponseDto.OrderSummaryDto;
+import com.spartaclub.orderplatform.domain.user.domain.entity.User;
+import com.spartaclub.orderplatform.domain.user.domain.entity.UserRole;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.mapstruct.factory.Mappers;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+
+//주문 조회 전략 인터페이스
+public interface OrderRoleQuery {
+
+    OrderMapper orderMapper = Mappers.getMapper(OrderMapper.class);
+
+    UserRole supports(); // 전략이 담당하는 역할
+
+    OrderDetailResponseDto getOrderDetail(UUID orderId, User viewer);
+
+    OrdersResponseDto getOrders(GetOrdersRequestDto requestDto,
+        User user,
+        Pageable pageable);
+
+    // 공통 구현: 다르면 오버라이드
+    default OrdersResponseDto getOrdersCommon(
+        GetOrdersRequestDto requestDto, User viewer, Pageable pageable,
+        OrderReader orderReader, OrderMapper orderMapper
+    ) {
+        OrderSpecQuery orderSpecQuery = new OrderSpecQuery(requestDto.status(), viewer);
+        Page<Order> orders = orderReader.findAll(orderSpecQuery, pageable);
+
+        List<OrderSummaryDto> ordersList = orders.getContent().stream()
+            .map(orderMapper::toSummaryDto)
+            .collect(Collectors.toList());
+
+        OrdersResponseDto.PageableDto meta = orderMapper.toPageableDto(orders);
+        return new OrdersResponseDto(ordersList, meta);
+    }
+}

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/domain/model/Order.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/domain/model/Order.java
@@ -4,9 +4,6 @@ import com.spartaclub.orderplatform.domain.order.application.command.PlaceOrderC
 import com.spartaclub.orderplatform.domain.order.exception.OrderErrorCode;
 import com.spartaclub.orderplatform.domain.payment.domain.model.Payment;
 import com.spartaclub.orderplatform.domain.product.domain.entity.Product;
-import com.spartaclub.orderplatform.domain.store.domain.model.Store;
-import com.spartaclub.orderplatform.global.domain.entity.BaseEntity;
-import com.spartaclub.orderplatform.global.exception.BusinessException;
 import com.spartaclub.orderplatform.domain.user.domain.entity.User;
 import com.spartaclub.orderplatform.global.domain.entity.BaseEntity;
 import com.spartaclub.orderplatform.global.exception.BusinessException;
@@ -51,9 +48,8 @@ public class Order extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "store_id", nullable = false)
-    private Store store;
+    @Column(name = "store_id", nullable = false)
+    private UUID storeId;
 
     @OneToMany(mappedBy = "order",
         cascade = CascadeType.ALL,        // Order 저장/삭제 시 자식도 같이
@@ -156,21 +152,17 @@ public class Order extends BaseEntity {
     }
 
     // User, Store 연관 관계 형성
-    private void link(User user, Store store) {
+    private void link(User user, UUID storeId) {
         this.user = user;
-
-        this.store = store;
-        if (!store.getOrders().contains(this)) {
-            store.getOrders().add(this);
-        }
+        this.storeId = storeId;
     }
 
     //주문 생성 정적 팩토리 메서드
-    public static Order place(User user, Store store, List<PlaceOrderCommand> commands,
+    public static Order place(User user, UUID storeId, List<PlaceOrderCommand> commands,
         Map<UUID, Product> products, String address, String memo) {
 
         Order order = new Order();
-        order.link(user, store);
+        order.link(user, storeId);
         order.status = OrderStatus.PAYMENT_PENDING;
         order.address = address;
         order.memo = memo;

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/domain/repository/OrderRepository.java
@@ -1,6 +1,6 @@
 package com.spartaclub.orderplatform.domain.order.domain.repository;
 
-import com.spartaclub.orderplatform.domain.order.application.query.OrderQuery;
+import com.spartaclub.orderplatform.domain.order.application.query.OrderSpecQuery;
 import com.spartaclub.orderplatform.domain.order.domain.model.Order;
 import java.util.Optional;
 import java.util.UUID;
@@ -11,7 +11,7 @@ public interface OrderRepository {
 
     Order save(Order order);
 
-    Page<Order> findAll(OrderQuery orderQuery, Pageable pageable);
+    Page<Order> findAll(OrderSpecQuery orderSpecQuery, Pageable pageable);
 
     Optional<Order> findById(UUID orderId);
 }

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/domain/repository/StoreReaderRepository.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/domain/repository/StoreReaderRepository.java
@@ -1,10 +1,10 @@
 package com.spartaclub.orderplatform.domain.order.domain.repository;
 
-import com.spartaclub.orderplatform.domain.store.domain.model.Store;
+import com.spartaclub.orderplatform.domain.order.domain.repository.dto.StoreSummary;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface StoreReaderRepository {
 
-    Optional<Store> findById(UUID storeId);
+    Optional<StoreSummary> loadStoreSummaryInfo(UUID storeId);
 }

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/domain/repository/dto/StoreSummary.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/domain/repository/dto/StoreSummary.java
@@ -1,0 +1,19 @@
+package com.spartaclub.orderplatform.domain.order.domain.repository.dto;
+
+import com.spartaclub.orderplatform.domain.store.application.facade.dto.StoreView;
+import java.util.UUID;
+
+public record StoreSummary(
+    UUID storeId,
+    String storeName,
+    Long ownerId
+) {
+
+    public static StoreSummary from(StoreView storeView) {
+        return new StoreSummary(
+            storeView.storeId(),
+            storeView.storeName(),
+            storeView.ownerId()
+        );
+    }
+}

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/infrastructure/repository/OrderJpaRepository.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/infrastructure/repository/OrderJpaRepository.java
@@ -14,15 +14,9 @@ import org.springframework.stereotype.Repository;
 public interface OrderJpaRepository extends JpaRepository<Order, UUID>,
     JpaSpecificationExecutor<Order> {
 
-    @EntityGraph(attributePaths = {"store", "user"})
-    Page<Order> findByUser_UserId(Long userId, Pageable pageable);
-
-    @EntityGraph(attributePaths = {"store", "user"})
-    Page<Order> findByStore_User_UserId(Long userId, Pageable pageable);
-
-    @EntityGraph(attributePaths = {"store", "user"})
+    @EntityGraph(attributePaths = {"user"})
     Page<Order> findAll(Pageable pageable);
 
-    @EntityGraph(attributePaths = {"store", "user"})
+    @EntityGraph(attributePaths = {"user"})
     Page<Order> findAll(Specification<Order> specification, Pageable pageable);
 }

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/infrastructure/repository/OrderRepositoryImpl.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/infrastructure/repository/OrderRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.spartaclub.orderplatform.domain.order.infrastructure.repository;
 
-import com.spartaclub.orderplatform.domain.order.application.query.OrderQuery;
+import com.spartaclub.orderplatform.domain.order.application.query.OrderSpecQuery;
 import com.spartaclub.orderplatform.domain.order.domain.model.Order;
 import com.spartaclub.orderplatform.domain.order.domain.repository.OrderRepository;
 import com.spartaclub.orderplatform.domain.order.infrastructure.repository.spec.OrderSpecs;
@@ -24,11 +24,11 @@ public class OrderRepositoryImpl implements OrderRepository {
     }
 
     @Override
-    public Page<Order> findAll(OrderQuery orderQuery, Pageable pageable) {
+    public Page<Order> findAll(OrderSpecQuery orderSpecQuery, Pageable pageable) {
         Specification<Order> spec = (root, query, cb) -> cb.conjunction(); // 초기값
         spec = spec
-            .and(OrderSpecs.visibleFor(orderQuery.viewer()))
-            .and(OrderSpecs.statusIn(orderQuery.status()));
+            .and(OrderSpecs.visibleFor(orderSpecQuery.viewer()))
+            .and(OrderSpecs.statusIn(orderSpecQuery.status()));
         return orderJpaRepository.findAll(spec, pageable);
     }
 

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/infrastructure/repository/StoreReaderRepositoryImpl.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/infrastructure/repository/StoreReaderRepositoryImpl.java
@@ -1,22 +1,22 @@
 package com.spartaclub.orderplatform.domain.order.infrastructure.repository;
 
 import com.spartaclub.orderplatform.domain.order.domain.repository.StoreReaderRepository;
-import com.spartaclub.orderplatform.domain.store.domain.model.Store;
-import com.spartaclub.orderplatform.domain.store.infrastructure.repository.StoreJpaRepository;
+import com.spartaclub.orderplatform.domain.order.domain.repository.dto.StoreSummary;
+import com.spartaclub.orderplatform.domain.store.application.facade.StorePublicReader;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Component;
 
-@Repository
+@Component
 @RequiredArgsConstructor
 public class StoreReaderRepositoryImpl implements StoreReaderRepository {
 
-    private final StoreJpaRepository storeJPARepository;
+    private final StorePublicReader storePublicReader;
 
     @Override
-    public Optional<Store> findById(UUID storeId) {
-        return storeJPARepository.findById(storeId);
+    public Optional<StoreSummary> loadStoreSummaryInfo(UUID storeId) {
+        return storePublicReader.loadStoreSummaryInfo(storeId).map(StoreSummary::from);
     }
 }
 // TODO: StoreJPARepository 생기면 수정하기

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/infrastructure/repository/spec/OrderSpecs.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/infrastructure/repository/spec/OrderSpecs.java
@@ -2,6 +2,7 @@ package com.spartaclub.orderplatform.domain.order.infrastructure.repository.spec
 
 import com.spartaclub.orderplatform.domain.order.domain.model.Order;
 import com.spartaclub.orderplatform.domain.order.domain.model.OrderStatus;
+import com.spartaclub.orderplatform.domain.store.domain.model.Store;
 import com.spartaclub.orderplatform.domain.user.domain.entity.User;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -14,7 +15,19 @@ public final class OrderSpecs {
     public static Specification<Order> visibleFor(User viewer) {
         return (root, q, cb) -> switch (viewer.getRole()) {
             case CUSTOMER -> cb.equal(root.get("user").get("userId"), viewer.getUserId());
-            case OWNER -> cb.equal(root.get("store").get("user").get("userId"), viewer.getUserId());
+            case OWNER -> {
+                // EXISTS (select 1 from Store s
+                //         where s.storeId = order.storeId
+                //           and s.user.userId = :viewerUserId)
+                var sub = q.subquery(Integer.class);
+                var s = sub.from(Store.class);
+                sub.select(cb.literal(1));
+                sub.where(
+                    cb.equal(s.get("storeId"), root.get("storeId")),
+                    cb.equal(s.get("user").get("userId"), viewer.getUserId())
+                );
+                yield cb.exists(sub);
+            }
             case MASTER, MANAGER -> cb.conjunction(); // 모두 허용
             default -> cb.disjunction(); // 서비스에서 AccessDeniedException
         };

--- a/src/main/java/com/spartaclub/orderplatform/domain/order/presentation/controller/OrderController.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/order/presentation/controller/OrderController.java
@@ -1,6 +1,7 @@
 package com.spartaclub.orderplatform.domain.order.presentation.controller;
 
-import com.spartaclub.orderplatform.domain.order.application.OrderService;
+import com.spartaclub.orderplatform.domain.order.application.service.OrderService;
+import com.spartaclub.orderplatform.domain.order.application.service.query.OrderQueryFacade;
 import com.spartaclub.orderplatform.domain.order.presentation.dto.request.GetOrdersRequestDto;
 import com.spartaclub.orderplatform.domain.order.presentation.dto.request.PlaceOrderRequestDto;
 import com.spartaclub.orderplatform.domain.order.presentation.dto.response.OrderDetailResponseDto;
@@ -41,6 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
 
     private final OrderService orderService;
+    private final OrderQueryFacade orderQueryFacade;
 
     // 주문 생성 API
     @Operation(
@@ -108,7 +110,7 @@ public class OrderController {
         @PathVariable UUID orderId
     ) {
         return ResponseEntity.ok(
-            ApiResponse.success(orderService.getOrderDetail(orderId, userDetails)));
+            ApiResponse.success(orderQueryFacade.getOrderDetail(orderId, userDetails.getUser())));
     }
 
     // 주문 목록 조회
@@ -141,7 +143,8 @@ public class OrderController {
         @ParameterObject Pageable pageable
     ) {
         return ResponseEntity.ok(
-            ApiResponse.success(orderService.getOrders(requestDto, userDetails, pageable)));
+            ApiResponse.success(
+                orderQueryFacade.getOrders(requestDto, userDetails.getUser(), pageable)));
     }
 
     // 주문 취소

--- a/src/main/java/com/spartaclub/orderplatform/domain/payment/application/PaymentService.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/payment/application/PaymentService.java
@@ -5,7 +5,7 @@ import static com.spartaclub.orderplatform.domain.payment.domain.model.PaymentSt
 import static com.spartaclub.orderplatform.domain.payment.domain.model.PaymentStatus.FAILED;
 import static com.spartaclub.orderplatform.domain.payment.domain.model.PaymentStatus.REFUNDED;
 
-import com.spartaclub.orderplatform.domain.order.application.OrderService;
+import com.spartaclub.orderplatform.domain.order.application.service.OrderService;
 import com.spartaclub.orderplatform.domain.order.domain.model.Order;
 import com.spartaclub.orderplatform.domain.payment.application.dto.query.PaymentQuery;
 import com.spartaclub.orderplatform.domain.payment.application.mapper.PaymentMapper;

--- a/src/main/java/com/spartaclub/orderplatform/domain/payment/infrastructure/pg/TossPaymentsClient.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/payment/infrastructure/pg/TossPaymentsClient.java
@@ -1,13 +1,25 @@
 package com.spartaclub.orderplatform.domain.payment.infrastructure.pg;
 
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Component
+@Slf4j
 public class TossPaymentsClient {
+
+    public TossPaymentsClient(WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    @Qualifier("tossWebClient")
+    private final WebClient webClient;
 
     //PG사에 결제 요청 실제 연동 X
     public String requestPaymentReady(Long amount) {
+        log.info("[TossPaymentsClient] 결제 준비 요청 - amount={}", amount);
         /*PG사 결제 요청 실제 연동 하지 않으므로
          * redirectUrl 임의로 생성*/
         return "https://store.com/success?paymentKey="
@@ -18,12 +30,44 @@ public class TossPaymentsClient {
 
     //PG사 결제 승인
     public boolean confirmPayment(String paymentKey, String orderId, Long amount) {
+        log.info("[TossPaymentsClient] 결제 승인 요청 - paymentKey={}, orderId={}, amount={}",
+            paymentKey, orderId, amount);
+        // WebClient로 실제 연동 시:
+        /*
+        return webClient.post()
+            .uri("/v1/payments/confirm")
+            .bodyValue(Map.of(
+                "paymentKey", paymentKey,
+                "orderId", orderId,
+                "amount", amount
+            ))
+            .retrieve()
+            .bodyToMono(Boolean.class)
+            .block();
+        */
+
         /*실제 PG 연동하지 않기 때문에 무조건 true*/
         return true;
     }
 
     //결제 환불 요청
     public boolean cancelPayment(String paymentKey, String cancelReason) {
+        log.info("[TossPaymentsClient] 결제 취소 요청 - paymentKey={}, reason={}", paymentKey,
+            cancelReason);
+
+        // 실제 연동 시 예시:
+        /*
+        return webClient.post()
+            .uri("/v1/payments/cancel")
+            .bodyValue(Map.of(
+                "paymentKey", paymentKey,
+                "cancelReason", cancelReason
+            ))
+            .retrieve()
+            .bodyToMono(Boolean.class)
+            .block();
+        */
+
         /*실제 PG 연동하지 않기 때문에 무조건 true*/
         return true;
     }

--- a/src/main/java/com/spartaclub/orderplatform/domain/review/application/service/ReviewService.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/review/application/service/ReviewService.java
@@ -1,7 +1,7 @@
 package com.spartaclub.orderplatform.domain.review.application.service;
 
 
-import com.spartaclub.orderplatform.domain.order.application.OrderService;
+import com.spartaclub.orderplatform.domain.order.application.service.OrderService;
 import com.spartaclub.orderplatform.domain.order.domain.model.Order;
 import com.spartaclub.orderplatform.domain.product.application.service.ProductService;
 import com.spartaclub.orderplatform.domain.product.domain.entity.Product;

--- a/src/main/java/com/spartaclub/orderplatform/domain/store/application/facade/StorePublicReader.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/store/application/facade/StorePublicReader.java
@@ -12,4 +12,10 @@ import java.util.UUID;
 public interface StorePublicReader {
 
     Optional<StoreView> loadStoreSummaryInfo(UUID storeId);
+    /*
+    더 구현 해볼만한 메서드
+    List<StoreView> findByOwner(Long ownerId);                     // 오너의 모든 가게
+    Page<StoreView> search(StoreSearchQuery query, Pageable pageable); // 검색/페이징
+    Optional<StoreDetailView> loadStoreDetail(UUID storeId);       // 더 풍부한 상세 뷰
+     */
 }

--- a/src/main/java/com/spartaclub/orderplatform/domain/store/application/facade/StorePublicReader.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/store/application/facade/StorePublicReader.java
@@ -1,0 +1,15 @@
+package com.spartaclub.orderplatform.domain.store.application.facade;
+
+import com.spartaclub.orderplatform.domain.store.application.facade.dto.StoreView;
+import java.util.Optional;
+import java.util.UUID;
+
+/*
+    공개용 인터페이스(퍼사드)
+    다른 도메인에서 Store 관련 데이터는 반드시 이 인터페이스를 통해서만 접근
+    내부 로직을 감추고 단일 진입점 제공
+ */
+public interface StorePublicReader {
+
+    Optional<StoreView> loadStoreSummaryInfo(UUID storeId);
+}

--- a/src/main/java/com/spartaclub/orderplatform/domain/store/application/facade/StorePublicReaderImpl.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/store/application/facade/StorePublicReaderImpl.java
@@ -1,0 +1,21 @@
+package com.spartaclub.orderplatform.domain.store.application.facade;
+
+import com.spartaclub.orderplatform.domain.store.application.facade.dto.StoreView;
+import com.spartaclub.orderplatform.domain.store.domain.repository.StoreRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StorePublicReaderImpl implements StorePublicReader {
+
+    private final StoreRepository storeRepository;
+
+    @Override
+    public Optional<StoreView> loadStoreSummaryInfo(UUID storeId) {
+        return storeRepository.findById(storeId)
+            .map(StoreView::from);
+    }
+}

--- a/src/main/java/com/spartaclub/orderplatform/domain/store/application/facade/StorePublicReaderImpl.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/store/application/facade/StorePublicReaderImpl.java
@@ -15,6 +15,10 @@ public class StorePublicReaderImpl implements StorePublicReader {
 
     @Override
     public Optional<StoreView> loadStoreSummaryInfo(UUID storeId) {
+        /*퍼사드 계층에서 할 수 있는 것들
+          도메인 간 접근 제어
+          제공 데이터 필터링
+        * */
         return storeRepository.findById(storeId)
             .map(StoreView::from);
     }

--- a/src/main/java/com/spartaclub/orderplatform/domain/store/application/facade/dto/StoreView.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/store/application/facade/dto/StoreView.java
@@ -1,0 +1,18 @@
+package com.spartaclub.orderplatform.domain.store.application.facade.dto;
+
+import com.spartaclub.orderplatform.domain.store.domain.model.Store;
+import java.util.UUID;
+
+public record StoreView(
+    UUID storeId,
+    String storeName,
+    Long ownerId
+) {
+
+    public static StoreView from(Store store) {
+        return new StoreView(
+            store.getStoreId(),
+            store.getStoreName(),
+            store.getUser().getUserId());
+    }
+}

--- a/src/main/java/com/spartaclub/orderplatform/domain/store/domain/model/Store.java
+++ b/src/main/java/com/spartaclub/orderplatform/domain/store/domain/model/Store.java
@@ -6,7 +6,6 @@ import static com.spartaclub.orderplatform.domain.store.domain.model.StoreStatus
 import static jakarta.persistence.EnumType.STRING;
 
 import com.spartaclub.orderplatform.domain.category.domain.model.Category;
-import com.spartaclub.orderplatform.domain.order.domain.model.Order;
 import com.spartaclub.orderplatform.domain.product.domain.entity.Product;
 import com.spartaclub.orderplatform.domain.review.domain.model.Review;
 import com.spartaclub.orderplatform.domain.store.presentation.dto.request.StoreRequestDto;
@@ -47,9 +46,6 @@ public class Store extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
-
-    @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Order> orders = new ArrayList<>();
 
     @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Product> products = new ArrayList<>();

--- a/src/main/java/com/spartaclub/orderplatform/global/config/web/WebClientConfig.java
+++ b/src/main/java/com/spartaclub/orderplatform/global/config/web/WebClientConfig.java
@@ -1,0 +1,19 @@
+package com.spartaclub.orderplatform.global.config.web;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean(name = "tossWebClient")
+    public WebClient tossWebClient() {
+        return WebClient.builder()
+            .baseUrl("https://api.tosspayments.com/v1")
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build();
+    }
+}


### PR DESCRIPTION
- PublicReader는 퍼사드 패턴+포트어댑터 패턴을 통해 구현했습니다. 다른 도메인의 데이터를 조회할 때 공개 인터페이스(퍼사드)를 통해 데이터를 담당하는 도메인이 단일 진입점을 제공하는 방식. 다른 도메인에게 단일 진입점을 제공하는 역할.

<img width="800" height="669" alt="image" src="https://github.com/user-attachments/assets/82a62434-989d-4458-9264-870ea506b335" />

- QueryFacade는 퍼사드 + 전략 패턴을 적용했습니다. 유저의 역할 별 조회 전략을 분리하고, 퍼사드가 역할별 전략으로 라우팅하게 됩니다.
Presentation (Controller) 계층에 단일 진입점 제공하는 역할.
<img width="802" height="745" alt="image" src="https://github.com/user-attachments/assets/a85599d6-651f-4a1c-8969-038db231d4ac" />

- Order–Store 연관관계를 엔티티 직접 참조에서 ID 간접 참조로 변경하여 도메인 간 의존성을 낮췄습니다. 이를 통해 트랜잭션 경계를 명확하게 만들어 의도하지 않은 N+1 같은 쿼리를 방지할 수 있고, 기술의 변경이나 마이크로서비스 전환 시 유연하게 변경이 가능하게 했습니다.
